### PR TITLE
Meta-grammar replacement bug

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,13 +1,61 @@
+use std::{fmt::Debug, collections::VecDeque};
+
+use bevy::prelude::Res;
+
+#[derive(Clone, PartialEq, Debug)]
 /// This defines a portion of a token stream that may be replaced using a rule, or might already be ready
-pub enum Replacable<ResultType, RuleKeyType> {
+pub enum Replacable<RuleKeyType: Clone + PartialEq + Debug, ResultType: Clone + PartialEq + Debug> {
     /// The value is already in it's final form
     Ready(ResultType),
     /// The value can be replaced by the provided rule
     Replace(RuleKeyType),
+    /// The value is a meta rule for immediate processing
+    ImmediateMeta(RuleKeyType, ResultType),
+    /// The value is a meta rule for delayed processing - basically aliasing the rule
+    DelayedMeta(RuleKeyType, ResultType)
+}
+
+/// This sets the direction of processing for the grammar
+#[derive(Clone, Copy, Debug)]
+pub enum GrammarProcessingDirection {
+    /// Breadth first means it first iterates once through an entire stream - only making initial replacements, but not processing their values yet.
+    /// It then is able to apply the next iteration - until it either reaches a maximum depth or stabilizes.
+    BreadthFirst,
+    /// Depth first means it goes in sequence through the stream, and each time it is able to make a replacement it replaces it as far as it can go.
+    /// This will not evolve, and cannot detect new emergent patterns in a stream, but can be very effective for specific contexts like text generation.
+    DepthFirst
+}
+
+impl Default for GrammarProcessingDirection {
+    fn default() -> Self {
+        Self::BreadthFirst
+    }
+}
+
+/// This trait defines a random number generator capable of choosing a single item from a list of len usize.
+/// It is used for selecting a rule for using when multiple rules are available.
+pub trait GrammarRandomNumberGenerator {
+    /// This function provides a random number between 0 and len
+    fn get_number(&mut self, len: usize) -> usize;
+}
+
+impl<T:FnMut(usize) -> usize>  GrammarRandomNumberGenerator for T {
+    fn get_number(&mut self, len: usize) -> usize {
+        if len == 0 {
+            return 0;
+        }
+        self(len)
+    }
+}
+
+impl GrammarRandomNumberGenerator for usize {
+    fn get_number(&mut self, _: usize) -> usize {
+        self.clone()
+    }
 }
 
 /// This trait defines an interface for a grammar
-pub trait Grammar<RuleKeyType, ResultType: Clone> {
+pub trait Grammar<RuleKeyType: Clone + PartialEq + Debug, ResultType: Clone + PartialEq + Debug, StreamType: Clone + PartialEq + Debug> {
     /// Gets a Vec of all the possible rule keys - can be used to see if any match
     fn rule_keys(&self) -> &Vec<RuleKeyType>;
     /// Checks if a given rule key is available
@@ -21,19 +69,22 @@ pub trait Grammar<RuleKeyType, ResultType: Clone> {
     /// The bool is true if there are no more tokens that need replacing
     fn check_token_stream(
         &self,
-        stream: &[&ResultType],
-    ) -> (bool, Vec<Replacable<ResultType, RuleKeyType>>);
+        stream: &StreamType,
+    ) -> (bool, Vec<Replacable<RuleKeyType, ResultType>>);
 
     /// Selects an element from a rule's options. provides a default implementation in case no weighting is ncessessary.
     /// The RNG function should accept the total number of options, and return a single id (a number less than the total). If it is larger, we will use the last element.
-    fn select_from_rule<R: FnMut(usize) -> usize>(
+    fn select_from_rule<R: GrammarRandomNumberGenerator>(
         &self,
         rule: &RuleKeyType,
         rng: &mut R,
     ) -> Option<&ResultType> {
         if let Some(options) = self.get_rule_options(rule) {
-            let len = options.len() - 1;
-            let index = len.min(rng(len));
+            let len = options.len();
+            let max = len.checked_sub(1).unwrap_or_default();
+            let rng = rng.get_number(len);
+            let index = max.min(rng);
+            println!("Selecting from - len: {}, max id: {}, rng: {}, selected: {}",len, max, rng, index);
             options.get(index)
         } else {
             None
@@ -43,59 +94,178 @@ pub trait Grammar<RuleKeyType, ResultType: Clone> {
     /// Converts a rule key to a default result, in case no matching rule is found in the grammar.
     fn rule_to_default_result(&self, rule: &RuleKeyType) -> ResultType;
 
-    /// Takes a token stream, checks it for replacements, and then applies them by using select from rule.
-    /// It returns a bool indicating whether it had to make any replacements this round, and a vec of the results.
-    fn apply_token_stream<R: FnMut(usize) -> usize>(
-        &self,
-        stream: &[&ResultType],
-        mut rng: &mut R,
-    ) -> (bool, Vec<ResultType>) {
-        let (is_done, values) = self.check_token_stream(stream);
-        (
-            is_done,
-            values
-                .iter()
-                .map(|v| match v {
-                    Replacable::Ready(v) => v.clone(),
-                    Replacable::Replace(v) => self
-                        .select_from_rule(v, &mut rng)
-                        .cloned()
-                        .unwrap_or(self.rule_to_default_result(v)),
-                })
-                .collect(),
-        )
-    }
-}
+    /// Converts a group result types to a stream type
+    fn result_to_stream(&self, result: &[ResultType]) -> StreamType;
 
-/// A trait for Stateful grammars - grammars that can evolve with additional rules over time.
-pub trait StatefulGrammar<RuleKeyType, ResultType: Clone>:
-    Grammar<RuleKeyType, ResultType> + Clone
-{
+    /// Converts a stream to a vec of result type
+    fn stream_to_result(&self, stream: &StreamType) -> Vec<ResultType>;
+
+    /// determines if the grammar should be processed breadth-first or depth-first
+    fn processing_direction(&self) -> GrammarProcessingDirection;
+
+    
     /// This is a function for setting a new rule. The expectation is that it overrides the original.
     fn set_additional_rules(&mut self, rule: RuleKeyType, values: &[ResultType]);
+
+    /// This is used to clone all the roles from another grammar into this one. This is used by stateful generators to update their state.
+    fn copy_and_replace_rules(&mut self, other: &Self) {
+        for rule in other.rule_keys() {
+            if let Some(values) = other.get_rule_options(rule) {
+                let rule = rule.clone();
+                self.set_additional_rules(rule, values);
+            }
+        }
+    }
+
+    /// Provides the maximum depth (number of iterations) allowed for the generator. It will always quit early if it stabilizes,
+    /// but otherwise it will conclude when it reaches the provided depth.
+    fn max_depth(&self) -> usize {
+        50
+    }
+
+    /// Takes a token stream, checks it for replacements, and then applies them by using select from rule.
+    /// It returns a bool indicating whether it had to make any replacements this round, and a vec of the results.
+    fn process_stream<R: GrammarRandomNumberGenerator>(
+        &self,
+        stream: &StreamType,
+        rng: &mut R,
+        temporary_grammar: &mut Self
+    ) -> StreamType {
+        println!("Applying Token Stream to {:?}", stream);
+
+        match self.processing_direction() {
+            GrammarProcessingDirection::BreadthFirst => {
+                self.breadth_first_processing(stream, temporary_grammar, rng)
+            },
+            GrammarProcessingDirection::DepthFirst => todo!(),
+        }
+    }
+
+    /// Processes a stream breadth first, regardless of the settings of the grammar 
+    fn breadth_first_processing<R: GrammarRandomNumberGenerator>(&self, stream: &StreamType, temporary_grammar: &mut Self, rng: &mut R) -> StreamType {
+        println!("Breadth First");
+        let MAX_DEPTH = self.max_depth();
+        let (skippable, initial) = self.check_token_stream(stream);
+        if skippable {
+            println!("Fully skippable");
+            return stream.clone();
+        }
+
+        let mut queue: Vec<(Option<RuleKeyType>, Vec<Replacable<RuleKeyType, ResultType>>)> = vec![(None, initial)];
+        let mut append_to_queue = vec![];
+        let mut depth = 0;
+        let mut result = stream.clone();
+        let mut tmp_result = None;
+        while let Some((target, current)) = queue.pop() {
+            println!("**** ITERATION *****");
+            println!("Target: {:?}\nInput:\n{:?}", &target, &current);
+            let next = current.into_iter().filter_map(|token| {
+               let result = match token {
+                    Replacable::Ready(v) => Some(v),
+                    Replacable::Replace(key) => {
+                        if let Some(result) = temporary_grammar.select_from_rule(&key, rng) {
+                            Some(result.clone())
+                        } else if let Some(result) = self.select_from_rule(&key, rng) {
+                            Some(result.clone())
+                        } else {
+                            Some(self.rule_to_default_result(&key))
+                        }
+                    },
+                    Replacable::ImmediateMeta(key, value) => {
+                        let stream = self.result_to_stream(&[value.clone()]);
+                        let (skippable, replaceables) = self.check_token_stream(&stream);
+                        if skippable {
+                            temporary_grammar.set_additional_rules(key, &[value]);
+                        } else {
+                            append_to_queue.push((Some(key), replaceables));
+                        }
+                        None
+                    },
+                    Replacable::DelayedMeta(key, value) => {
+                        temporary_grammar.set_additional_rules(key, &[value]);
+                        None
+                    },
+                };
+                result
+            }).collect::<Vec<_>>();
+    
+            println!("Result:\n{:?}", &next);
+    
+            let next = self.result_to_stream(&next);
+    
+            println!("Stream:\n{:?}", &next);
+    
+            if let Some(target) = &target {
+                println!("got a target");
+                if let Some(tmp) = &tmp_result {
+                
+                    println!("and a temp result");
+                    if tmp == &next {
+                    
+                println!("they match");
+                        temporary_grammar.set_additional_rules(target.clone(), &self.stream_to_result(&next));
+                        tmp_result = None;
+                        continue;
+                    }
+                    println!("they don't match - carry on");
+                }
+                tmp_result = Some(next.clone());
+            } else if result == next {
+                println!("no target - and result = next - ending early");
+                break;
+            } else {
+                println!("no target, keep going...");
+                result = next.clone();
+            }
+    
+            
+            depth += 1;
+            if depth >= MAX_DEPTH {
+                break;
+            }
+        
+            println!("Checking next stream:\n{:?}", next);
+            let (skippable, next) = self.check_token_stream(&next);
+            println!("Setting up for next stream:\nis skippable: {skippable}\n{:?}", next);
+            if skippable {
+                if let (Some(target), Some(tmp)) = (&target, tmp_result) {
+                    temporary_grammar.set_additional_rules(target.clone(), &self.stream_to_result(&tmp));
+                    tmp_result = None;
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            queue.push((target, next));
+            queue.append(&mut append_to_queue);
+        }
+        result
+    }
+    
 }
+
 
 /// This trait represents a stateless generator. You pass the grammar & rng in, and it can provide the resulting stream.
 pub trait Generator<
-    RuleKeyType: Clone,
-    GrammarResultType: Clone,
-    GrammarType: Grammar<RuleKeyType, GrammarResultType>,
-    StreamType,
+    RuleKeyType: Clone + PartialEq + Debug,
+    GrammarResultType: Clone + PartialEq + Debug,
+    StreamType: Clone+ PartialEq + Debug,
+    GrammarType: Grammar<RuleKeyType, GrammarResultType, StreamType>,
 >
 {
     /// This function generates a new value of `StreamType`, starting from the grammar's default rule
-    fn generate<R: FnMut(usize) -> usize>(grammar: &GrammarType, rng: &mut R)
+    fn generate<R: GrammarRandomNumberGenerator>(grammar: &GrammarType, rng: &mut R)
         -> Option<StreamType>;
 
     /// This function generates a new value of `StreamType`, starting from a provided rule key
-    fn generate_at<R: FnMut(usize) -> usize>(
+    fn generate_at<R: GrammarRandomNumberGenerator>(
         key: &RuleKeyType,
         grammar: &GrammarType,
         rng: &mut R,
     ) -> Option<StreamType>;
 
     /// This function generates a new value of `StreamType`, starting by processing an initial input of `StreamType`
-    fn expand_from<R: FnMut(usize) -> usize>(
+    fn expand_from<R: GrammarRandomNumberGenerator>(
         initial: &StreamType,
         grammar: &GrammarType,
         rng: &mut R,
@@ -103,19 +273,21 @@ pub trait Generator<
 }
 
 /// This enum helps handling comples meta-commands within a stream.
-pub enum MetaRuleProcessingResult<GrammarResultType, StreamType> {
+pub enum MetaRuleProcessingResult<RuleKey, GrammarResultType, StreamType> {
+    /// This is just content
+    Raw(StreamType),
     /// This will immediately process the result of the command, so the processed result is consistent when the new rule is used
-    ProcessImmediately(StreamType),
+    ImmediateMeta(RuleKey, StreamType),
     /// This will store the result directly in the ruleset, and process it only when called - allowing for multiple possible results
-    ProcessWhenUsed(GrammarResultType),
+    DelayedMeta(RuleKey, GrammarResultType),
 }
 
 /// This trait represents a stateful generator. Here the generator owns the grammar, allowing it to make adjustments as needed.
 pub trait StatefulGenerator<
-    RuleKeyType: Clone,
-    GrammarResultType: Clone,
-    GrammarType: StatefulGrammar<RuleKeyType, GrammarResultType>,
-    StreamType,
+    RuleKeyType: Clone + PartialEq + Debug,
+    GrammarResultType: Clone + PartialEq + Debug,
+    StreamType: Clone + PartialEq + Debug,
+    GrammarType: Grammar<RuleKeyType, GrammarResultType, StreamType>,
 >
 {
     /// This sets the used grammar
@@ -126,35 +298,19 @@ pub trait StatefulGenerator<
     fn get_grammar_mut(&mut self) -> &mut GrammarType;
 
     /// This function generates a new value of `StreamType`, starting from the grammar's default rule
-    fn generate<R: FnMut(usize) -> usize>(&mut self, rng: &mut R) -> Option<StreamType>;
+    fn generate<R: GrammarRandomNumberGenerator>(&mut self, rng: &mut R) -> Option<StreamType>;
 
     /// This function generates a new value of `StreamType`, starting from a provided rule key
-    fn generate_at<R: FnMut(usize) -> usize>(
+    fn generate_at<R: GrammarRandomNumberGenerator>(
         &mut self,
         key: &RuleKeyType,
         rng: &mut R,
     ) -> Option<StreamType>;
 
     /// This function generates a new value of `StreamType`, starting by processing an initial input of `StreamType`
-    fn expand_from<R: FnMut(usize) -> usize>(
+    fn expand_from<R: GrammarRandomNumberGenerator>(
         &mut self,
         initial: &StreamType,
         rng: &mut R,
     ) -> StreamType;
-
-    /// This function processes a stream, and determines which rules require updating.
-    /// The result is a tuple, containing the following:
-    /// - A version of the stream without the meta commands (that update the ruleset)
-    /// - A vec of (`RuleKeyType`, `MetaRuleProcessingResult`)
-    fn grab_rules_from_result<R: FnMut(usize) -> usize>(
-        &mut self,
-        result: &StreamType,
-        rng: &mut R,
-    ) -> (
-        StreamType,
-        Vec<(
-            RuleKeyType,
-            MetaRuleProcessingResult<RuleKeyType, StreamType>,
-        )>,
-    );
 }

--- a/src/tracery.rs
+++ b/src/tracery.rs
@@ -438,13 +438,18 @@ mod tests {
             &[
                 ("default", &["One", "#set#Hi #val#"]),
                 ("set", &["[val:#Two#]"]),
+                ("set_2", &["[val:#Two#]"]),
                 ("Two", &["Three", "#Four#"]),
                 ("Four", &["What is going on?"]),
+                ("Five", &["Hey there"]),
             ],
             Some("default"),
         );
-        let selection = StatefulStringGenerator(rule).generate(&mut |_| 1);
+        let mut stateful_string_generator = StatefulStringGenerator(rule);
+        let selection = stateful_string_generator.generate(&mut |_| 1);
         assert_eq!(selection.unwrap(), "Hi What is going on?");
+        let selection = stateful_string_generator.expand_from(&"#set_2#Oh #val#".to_string(),&mut |_| 1);
+        assert_eq!(selection, "Oh Hey there");
     }
 
     const RULES: &[(&str, &[&str])] = &[

--- a/src/tracery.rs
+++ b/src/tracery.rs
@@ -122,7 +122,6 @@ impl Grammar<String, String, String> for TraceryGrammar {
         let result = stream
             .split('[')
             .flat_map(|v| {
-                println!("Checking for meta in {v}");
                 if inside {
                     has_meta = true;
                     let mut result = vec![];
@@ -152,14 +151,12 @@ impl Grammar<String, String, String> for TraceryGrammar {
                     }
                     result
                 } else {
-                    println!("Marked as raw");
                     inside = true;
                     vec![MetaRuleProcessingResult::Raw(v)]
                 }
             })
             .flat_map(|v| match v {
                 MetaRuleProcessingResult::Raw(v) => {
-                    println!("Checking raw: {v}");
                     let mut ready = true;
                     v.split('#')
                         .filter_map(|v| {
@@ -194,7 +191,7 @@ impl Grammar<String, String, String> for TraceryGrammar {
     }
 
     fn processing_direction(&self) -> GrammarProcessingDirection {
-        GrammarProcessingDirection::BreadthFirst
+        GrammarProcessingDirection::DepthFirst
     }
 
     fn result_to_stream(&self, result: &[String]) -> String {
@@ -416,7 +413,7 @@ mod tests {
             &[
                 ("default", &["One", "#set#Hi #val#"]),
                 ("set", &["[val:#Two#]"]),
-                ("set_2", &["[val:#Two#]"]),
+                ("set_2", &["[val:#Five#]"]),
                 ("Two", &["Three", "#Four#"]),
                 ("Four", &["What is going on?"]),
                 ("Five", &["Hey there"]),

--- a/src/tracery.rs
+++ b/src/tracery.rs
@@ -65,6 +65,15 @@ mod deserialize {
 }
 
 impl TraceryGrammar {
+    /// This provides an empty tracery grammar.
+    /// Mostly used for handling stateless generators.
+    pub fn empty() -> Self {
+        Self {
+            rules: Default::default(),
+            keys: vec![],
+            starting_point: "origin".to_string(),
+        }
+    }
     /// This provides a new tracery grammar.
     /// You provide a set of rules as `(Key, &[Values])` and optionally a starting point.
     /// If no starting point is provided, we fall back on "origin"
@@ -89,7 +98,7 @@ impl TraceryGrammar {
     }
 }
 
-impl Grammar<String, String> for TraceryGrammar {
+impl Grammar<String, String, String> for TraceryGrammar {
     fn rule_keys(&self) -> &Vec<String> {
         &self.keys
     }
@@ -106,51 +115,102 @@ impl Grammar<String, String> for TraceryGrammar {
         self.rules.get(rule)
     }
 
-    fn check_token_stream(&self, stream: &[&String]) -> (bool, Vec<Replacable<String, String>>) {
-        let mut ready = true;
+    fn check_token_stream(&self, stream: &String) -> (bool, Vec<Replacable<String, String>>) {
         let mut has_replacements = false;
-        let result = stream
-            .iter()
-            .map(|v| v.to_string())
-            .fold("".to_string(), |s, v| format!("{s}{v}"))
-            .split('#')
-            .map(|v| {
-                if ready {
-                    ready = false;
-                    Replacable::Ready(v.to_string())
+        let mut has_meta = false;
+        let mut inside = false;
+        let result = stream.split('[').flat_map(|v| {
+            println!("Checking for meta in {v}");
+            if inside {
+                has_meta = true;
+                let mut result = vec![];
+                let mut split = v.split(']');
+                if let Some(inner) = split.next() {
+                    let mut split = inner.split_inclusive(&[':', '|']);
+                    if let (Some(key), Some(value)) = (split.next(), split.next()) {
+                        if key.ends_with(':') {
+                            result.push(MetaRuleProcessingResult::ImmediateMeta(&key[0..key.len() - 1], value));
+                        } else {
+                            result.push(MetaRuleProcessingResult::DelayedMeta(&key[0..key.len() - 1], value));
+                        }
+                    } else {
+                        result.push(MetaRuleProcessingResult::Raw(inner));
+                    }
                 } else {
-                    ready = true;
-                    has_replacements = true;
-                    Replacable::Replace(v.to_string())
+                    result.push(MetaRuleProcessingResult::Raw(v));
                 }
-            })
-            .collect();
-        (has_replacements, result)
+                while let Some(v) = split.next() {
+                    result.push(MetaRuleProcessingResult::Raw(v))
+                }
+                result
+            } else {
+                println!("Marked as raw");
+                inside = true;
+                vec![MetaRuleProcessingResult::Raw(v)]
+            }
+        })
+        .flat_map(|v| {
+            match v {
+                MetaRuleProcessingResult::Raw(v) => {
+                    println!("Checking raw: {v}");
+                    let mut ready = true;
+                    v.split('#')
+                    .filter_map(|v| {
+                        if ready {
+                            ready = false;
+                            if v.is_empty() {
+                                return None;
+                            }
+                            Some(Replacable::Ready(v.to_string()))
+                        } else {
+                            ready = true;
+                            has_replacements = true;
+                            Some(Replacable::Replace(v.to_string()))
+                        }
+                    }).collect::<Vec<_>>()
+                },
+                MetaRuleProcessingResult::ImmediateMeta(key, val) => vec![Replacable::ImmediateMeta(key.to_string(), val.to_string())],
+                MetaRuleProcessingResult::DelayedMeta(key, val) => vec![Replacable::DelayedMeta(key.to_string(), val.to_string())],
+            }
+        }).collect::<Vec<_>>();
+
+        (!has_replacements && !has_meta, result)
     }
 
     fn rule_to_default_result(&self, rule: &String) -> String {
         format!("#{rule}#")
     }
-}
 
-impl StatefulGrammar<String, String> for TraceryGrammar {
+    fn processing_direction(&self) -> GrammarProcessingDirection {
+        GrammarProcessingDirection::BreadthFirst
+    }
+
+    fn result_to_stream(&self, result: &[String]) -> String {
+        result.join("")
+    }
+
     fn set_additional_rules(&mut self, rule: String, values: &[String]) {
         self.keys.push(rule.clone());
         self.rules.insert(rule, values.into());
+    }
+
+    fn stream_to_result(&self, stream: &String) -> Vec<String> {
+        vec![stream.clone()]
     }
 }
 
 /// This is a stateless string generator based on the tracery grammar. Note that, since it's stateless, it does not support variables.
 pub struct StringGenerator;
 
-const MAX_DEPTH: usize = 50usize;
-
-impl Generator<String, String, TraceryGrammar, String> for StringGenerator {
-    fn generate<R: FnMut(usize) -> usize>(grammar: &TraceryGrammar, rng: &mut R) -> Option<String> {
+impl Generator<String, String, String, TraceryGrammar> for StringGenerator {
+    fn generate<R: GrammarRandomNumberGenerator>(
+        grammar: &TraceryGrammar,
+        rng: &mut R,
+    ) -> Option<String> {
         Self::generate_at(&grammar.default_starting_point().clone(), grammar, rng)
     }
 
-    fn generate_at<R: FnMut(usize) -> usize>(
+    fn generate_at<R: GrammarRandomNumberGenerator>(
         key: &String,
         grammar: &TraceryGrammar,
         rng: &mut R,
@@ -159,38 +219,13 @@ impl Generator<String, String, TraceryGrammar, String> for StringGenerator {
         initial.map(|initial| Self::expand_from(initial, grammar, rng))
     }
 
-    fn expand_from<R: FnMut(usize) -> usize>(
+    fn expand_from<R: GrammarRandomNumberGenerator>(
         initial: &String,
         grammar: &TraceryGrammar,
         rng: &mut R,
     ) -> String {
-        let mut queue = vec![initial.clone()];
-        let mut depth = 0;
-        let mut result = initial.clone();
-        while let Some(mut current) = queue.pop() {
-            let ready = match grammar.apply_token_stream(&[&current], rng) {
-                (true, results) => {
-                    current = results.join("");
-                    false
-                }
-                _ => true,
-            };
-
-            if result == current {
-                break;
-            }
-
-            if !ready {
-                queue.push(current.clone());
-            }
-            result = current;
-
-            depth += 1;
-            if depth >= MAX_DEPTH {
-                break;
-            }
-        }
-        result
+        let mut tmp = TraceryGrammar::empty();
+        grammar.process_stream(initial, rng, &mut tmp)
     }
 }
 
@@ -219,13 +254,13 @@ impl StatefulStringGenerator {
     }
 }
 
-impl StatefulGenerator<String, String, TraceryGrammar, String> for StatefulStringGenerator {
-    fn generate<R: FnMut(usize) -> usize>(&mut self, rng: &mut R) -> Option<String> {
+impl StatefulGenerator<String, String, String, TraceryGrammar> for StatefulStringGenerator {
+    fn generate<R: GrammarRandomNumberGenerator>(&mut self, rng: &mut R) -> Option<String> {
         let key = self.get_grammar().default_starting_point().clone();
         self.generate_at(&key, rng)
     }
 
-    fn generate_at<R: FnMut(usize) -> usize>(
+    fn generate_at<R: GrammarRandomNumberGenerator>(
         &mut self,
         key: &String,
         rng: &mut R,
@@ -236,59 +271,16 @@ impl StatefulGenerator<String, String, TraceryGrammar, String> for StatefulStrin
             .map(|initial| self.expand_from(&initial, rng))
     }
 
-    fn expand_from<R: FnMut(usize) -> usize>(
+    fn expand_from<R: GrammarRandomNumberGenerator>(
         &mut self,
         initial: &String,
         mut rng: &mut R,
     ) -> String {
-        let mut queue = vec![(None, initial.clone())];
-        let mut depth = 0;
-        let mut result = initial.clone();
-        while let Some((target, current)) = queue.pop() {
-            let (initial, rules_to_apply) = self.grab_rules_from_result(&current, &mut rng);
-
-            let mut next_result = initial.clone();
-
-            if !rules_to_apply.is_empty() {
-                queue.push((target, next_result.clone()));
-                for (rule_key, value) in rules_to_apply.iter() {
-                    match value {
-                        MetaRuleProcessingResult::ProcessImmediately(stream) => {
-                            queue.push((Some(rule_key.clone()), stream.clone()))
-                        }
-                        MetaRuleProcessingResult::ProcessWhenUsed(rule_value) => {
-                            self.0
-                                .set_additional_rules(rule_key.clone(), &[rule_value.to_string()]);
-                        }
-                    };
-                }
-                continue;
-            }
-
-            let mut ready = match self.get_grammar().apply_token_stream(&[&next_result], rng) {
-                (true, results) => {
-                    next_result = results.join("");
-                    false
-                }
-                _ => true,
-            };
-
-            if !ready && next_result == result {
-                ready = true;
-            }
-
-            if !ready {
-                queue.push((target, next_result.clone()));
-            } else if let Some(target) = target {
-                self.0.set_additional_rules(target, &[next_result.clone()]);
-            }
-            result = next_result;
-
-            depth += 1;
-            if depth >= MAX_DEPTH {
-                break;
-            }
-        }
+        let mut tmp = TraceryGrammar::empty();
+        let result = self
+            .get_grammar()
+            .process_stream(initial, rng, &mut tmp);
+        self.get_grammar_mut().copy_and_replace_rules(&tmp);
         result
     }
 
@@ -304,48 +296,48 @@ impl StatefulGenerator<String, String, TraceryGrammar, String> for StatefulStrin
         &mut self.0
     }
 
-    fn grab_rules_from_result<R: FnMut(usize) -> usize>(
-        &mut self,
-        result: &String,
-        _rng: &mut R,
-    ) -> (
-        String,
-        Vec<(String, MetaRuleProcessingResult<String, String>)>,
-    ) {
-        let mut new_rules = vec![];
-        let mut inside = false;
-        let result = result
-            .split('[')
-            .filter_map(|v| {
-                if inside {
-                    let mut split = v.split(']');
-                    if let Some(inner) = split.next() {
-                        let mut split = inner.split_inclusive(&[':', '|']);
-                        if let (Some(key), Some(value)) = (split.next(), split.next()) {
-                            if key.ends_with(':') {
-                                new_rules.push((
-                                    key[0..key.len() - 1].to_string(),
-                                    MetaRuleProcessingResult::ProcessImmediately(value.to_string()),
-                                ));
-                            } else {
-                                new_rules.push((
-                                    key[0..key.len() - 1].to_string(),
-                                    MetaRuleProcessingResult::ProcessWhenUsed(value.to_string()),
-                                ));
-                            }
-                        }
-                    } else {
-                        return None;
-                    }
-                    Some(split.fold("".to_string(), |a, b| format!("{a}{b}")))
-                } else {
-                    inside = true;
-                    Some(v.to_string())
-                }
-            })
-            .fold("".to_string(), |a, b| format!("{a}{b}"));
-        (result, new_rules)
-    }
+    // fn grab_rules_from_result<R: GrammarRandomNumberGenerator>(
+    //     &mut self,
+    //     result: &String,
+    //     _rng: &mut R,
+    // ) -> (
+    //     String,
+    //     Vec<(String, MetaRuleProcessingResult<String, String>)>,
+    // ) {
+    //     let mut new_rules = vec![];
+    //     let mut inside = false;
+    //     let result = result
+    //         .split('[')
+    //         .filter_map(|v| {
+    //             if inside {
+    //                 let mut split = v.split(']');
+    //                 if let Some(inner) = split.next() {
+    //                     let mut split = inner.split_inclusive(&[':', '|']);
+    //                     if let (Some(key), Some(value)) = (split.next(), split.next()) {
+    //                         if key.ends_with(':') {
+    //                             new_rules.push((
+    //                                 key[0..key.len() - 1].to_string(),
+    //                                 MetaRuleProcessingResult::ImmediateMeta(value.to_string()),
+    //                             ));
+    //                         } else {
+    //                             new_rules.push((
+    //                                 key[0..key.len() - 1].to_string(),
+    //                                 MetaRuleProcessingResult::DelayedMeta(value.to_string()),
+    //                             ));
+    //                         }
+    //                     }
+    //                 } else {
+    //                     return None;
+    //                 }
+    //                 Some(split.fold("".to_string(), |a, b| format!("{a}{b}")))
+    //             } else {
+    //                 inside = true;
+    //                 Some(v.to_string())
+    //             }
+    //         })
+    //         .fold("".to_string(), |a, b| format!("{a}{b}"));
+    //     (result, new_rules)
+    // }
 }
 
 #[cfg(test)]
@@ -355,16 +347,10 @@ mod tests {
     #[test]
     pub fn can_choose_a_single_element_from_a_list() {
         let rule = TraceryGrammar::new(&[("default", &["One", "Two"])], Some("default"));
-        let mut select = 0;
-        let mut fun = |_| {
-            let result = select;
-            select += 1;
-            result
-        };
 
-        assert_eq!(StringGenerator::generate(&rule, &mut fun).unwrap(), "One");
-        assert_eq!(StringGenerator::generate(&rule, &mut fun).unwrap(), "Two");
-        assert_eq!(StringGenerator::generate(&rule, &mut fun).unwrap(), "Two");
+        assert_eq!(StringGenerator::generate(&rule, &mut 0).unwrap(), "One");
+        assert_eq!(StringGenerator::generate(&rule, &mut 1).unwrap(), "Two");
+        assert_eq!(StringGenerator::generate(&rule, &mut 2).unwrap(), "Two");
     }
 
     #[test]
@@ -373,7 +359,7 @@ mod tests {
             &[("default", &["One", "#Two#"]), ("Two", &["Three", "Four"])],
             Some("default"),
         );
-        let selection = StringGenerator::generate(&rule, &mut |_| 1);
+        let selection = StringGenerator::generate(&rule, &mut 1);
         assert_eq!(selection.unwrap(), "Four");
     }
 
@@ -387,25 +373,18 @@ mod tests {
             ],
             Some("default"),
         );
-        let selection = StringGenerator::generate(&rule, &mut |_| 1);
+        let selection = StringGenerator::generate(&rule, &mut 1);
         assert_eq!(selection.unwrap(), "What");
     }
 
     #[test]
     pub fn stateful_can_choose_a_single_element_from_a_list() {
         let rule = TraceryGrammar::new(&[("default", &["One", "Two"])], Some("default"));
-        let mut select = 0;
-        let mut fun = |_| {
-            let result = select;
-            select += 1;
-            result
-        };
-
         let mut generator = StatefulStringGenerator(rule);
 
-        assert_eq!(generator.generate(&mut fun).unwrap(), "One");
-        assert_eq!(generator.generate(&mut fun).unwrap(), "Two");
-        assert_eq!(generator.generate(&mut fun).unwrap(), "Two");
+        assert_eq!(generator.generate(&mut 0).unwrap(), "One");
+        assert_eq!(generator.generate(&mut 1).unwrap(), "Two");
+        assert_eq!(generator.generate(&mut 2).unwrap(), "Two");
     }
 
     #[test]
@@ -414,7 +393,7 @@ mod tests {
             &[("default", &["One", "#Two#"]), ("Two", &["Three", "Four"])],
             Some("default"),
         );
-        let selection = StatefulStringGenerator(rule).generate(&mut |_| 1);
+        let selection = StatefulStringGenerator(rule).generate(&mut 1);
         assert_eq!(selection.unwrap(), "Four");
     }
 
@@ -428,12 +407,44 @@ mod tests {
             ],
             Some("default"),
         );
-        let selection = StatefulStringGenerator(rule).generate(&mut |_| 1);
+        let selection = StatefulStringGenerator(rule).generate(&mut 1);
         assert_eq!(selection.unwrap(), "What");
     }
 
     #[test]
     pub fn stateful_generator_can_set_value_and_use_it_later() {
+        let rule = TraceryGrammar::new(
+            &[
+                ("default", &["One", "[val:#Two#]Hi #val#"]),
+                ("Two", &["Three", "#Four#"]),
+                ("Four", &["What is going on?"]),
+                ("Five", &["Hey there"]),
+            ],
+            Some("default"),
+        );
+        let mut stateful_string_generator = StatefulStringGenerator(rule);
+        let selection = stateful_string_generator.generate(&mut 1);
+        assert_eq!(selection.unwrap(), "Hi What is going on?");
+    }
+
+    #[test]
+    pub fn stateful_generator_can_set_value_at_depth_and_use_it_later() {
+        let rule = TraceryGrammar::new(
+            &[
+                ("default", &["One", "#set#Hi #val#"]),
+                ("set", &["[val:#Two#]"]),
+                ("Two", &["Three", "#Four#"]),
+                ("Four", &["What is going on?"]),
+            ],
+            Some("default"),
+        );
+        let mut stateful_string_generator = StatefulStringGenerator(rule);
+        let selection = stateful_string_generator.generate(&mut 1);
+        assert_eq!(selection.unwrap(), "Hi What is going on?");
+    }
+
+    #[test]
+    pub fn stateful_generator_can_reset_a_value_at_depth_and_use_the_new_value() {
         let rule = TraceryGrammar::new(
             &[
                 ("default", &["One", "#set#Hi #val#"]),
@@ -446,9 +457,10 @@ mod tests {
             Some("default"),
         );
         let mut stateful_string_generator = StatefulStringGenerator(rule);
-        let selection = stateful_string_generator.generate(&mut |_| 1);
+        let selection = stateful_string_generator.generate(&mut 1);
         assert_eq!(selection.unwrap(), "Hi What is going on?");
-        let selection = stateful_string_generator.expand_from(&"#set_2#Oh #val#".to_string(),&mut |_| 1);
+        let selection =
+            stateful_string_generator.expand_from(&"#set_2#Oh #val#".to_string(), &mut 1);
         assert_eq!(selection, "Oh Hey there");
     }
 
@@ -490,17 +502,17 @@ mod tests {
     #[test]
     pub fn stateful_generator_works_with_complex_cases() {
         let mut generator = StatefulStringGenerator::new(RULES, None);
-        let selection = generator.generate(&mut |_| 1);
+        let selection = generator.generate(&mut 1);
         assert_eq!(
             selection.unwrap(),
             "many years ago there was a rabbit that found amountain."
         );
-        let next = generator.generate_at(&"next".to_string(), &mut |_| 1);
+        let next = generator.generate_at(&"next".to_string(), &mut 1);
         assert_eq!(
             next.unwrap(),
             "Our adventerous rabbit was ready to circle the mountain."
         );
-        let finally = generator.generate_at(&"finally".to_string(), &mut |_| 1);
+        let finally = generator.generate_at(&"finally".to_string(), &mut 1);
         assert_eq!(
             finally.unwrap(),
             "And so - after a challanging path - the lonely rabbit had proven their worth."


### PR DESCRIPTION
---
name: Meta-grammar replacement bug
about: Fix the meta-grammar replacement bug
title: 'Meta-grammar replacement bug'
labels: ""
assignees: 'lee-orr'
---

## What was the problem?

The issue is that if you have a meta-command (a command that changes grammar rules) that is issued by a replacement from further down the expansion process, it won't apply to uses of it immediately after.
In some cases, this might be desirable, while in others it isn't - so might be worth adding a "depth-first" vs "breadth first" configuration.

Mention any issues that this closes with "Closes #X" here.

## How did you fix it?

Briefly describe the steps you took to make this repository better.

## \[Optional\] What needs special attention?

If there are any particularly tricky areas of the PR that deserve extra attention, call them out here.
